### PR TITLE
Add Sign In support

### DIFF
--- a/controllers/auth/auth.go
+++ b/controllers/auth/auth.go
@@ -7,12 +7,14 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
+	"github.com/takeanote/takeanote-api/config"
 	"github.com/takeanote/takeanote-api/httputils"
 	"github.com/takeanote/takeanote-api/models"
-	"github.com/takeanote/takeanote-api/config"
 
 	"github.com/jinzhu/gorm"
+	"github.com/satori/go.uuid"
 	"gopkg.in/redis.v3"
 )
 
@@ -21,6 +23,8 @@ var (
 	ErrTokenInvalid = errors.New("token invalid or expired")
 	// ErrAccountAlreadyExist is returned if an email already exists in the db.
 	ErrAccountAlreadyExist = errors.New("the account already exist")
+	// ErrInvalidCredentials is returned if an email and password don't match a db entry.
+	ErrInvalidCredentials = errors.New("invalid credentials")
 	// ErrWrongPassword is returned if the provided password doesn't match.
 	ErrWrongPassword = errors.New("wrong password")
 )
@@ -30,6 +34,16 @@ type user struct {
 	LastName  string `json:"lastname"`
 	Email     string `json:"email"`
 	Password  string `json:"password"`
+}
+
+const (
+	// TokenDuration is validity duration of a token.
+	TokenDuration = 24 * time.Hour
+)
+
+// Token holds the user token
+type Token struct {
+	Token string `json:"token"`
 }
 
 // Controller handles authentication routines.
@@ -80,6 +94,34 @@ func (controller Controller) SignUp(w http.ResponseWriter, r *http.Request, vars
 	}
 
 	httputils.WriteJSON(w, http.StatusNoContent, nil)
+
+	return nil
+}
+
+// SignIn handles User creation
+func (controller Controller) SignIn(w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	user := &user{}
+	dbUser := &models.User{}
+
+	if err := json.NewDecoder(r.Body).Decode(user); err != nil {
+		httputils.WriteError(w, models.NewError(http.StatusBadRequest, err))
+		return err
+	}
+	user.Email = strings.ToLower(user.Email)
+
+	err := controller.DB.Where("email = ? AND password = ?",
+		user.Email, hashPassword(user.Password)).Find(&dbUser).Error
+	if err != nil {
+		httputils.WriteError(w, models.NewError(http.StatusUnauthorized, ErrInvalidCredentials))
+		return err
+	}
+
+	uuid := uuid.NewV4()
+	controller.RedisClient.Set(uuid.String(), user.Email, TokenDuration)
+
+	httputils.WriteJSON(w, http.StatusOK, Token{
+		Token: uuid.String(),
+	})
 
 	return nil
 }

--- a/router/routes.go
+++ b/router/routes.go
@@ -80,7 +80,7 @@ func NewHeadRoute(path string, handler httputils.APIFunc) Route {
 func New(config *config.Config) Router {
 	r := &router{}
 	if db, err := models.OpenDBWithConfig(config); err != nil {
-		panic(fmt.Errorf("Fatal error cannot connect to database: %s\n", err))
+		panic(fmt.Errorf("fatal error cannot connect to database: %s\n", err))
 	} else {
 		r.initRoutes(&db, config)
 	}
@@ -101,6 +101,7 @@ func (r *router) initRoutes(db *gorm.DB, cfg *config.Config) {
 		// GET
 		// POST
 		NewPostRoute("/signup", auth.SignUp),
+		NewPostRoute("/signin", auth.SignIn),
 		// PUT
 		// PATCH
 		// DELETE


### PR DESCRIPTION
Add availability to user to sign in using their credentials.

Here is a curl example to connect:

``` sh
curl -X POST -i -d '{"email":"test@test.fr", "password":"testtest"}' 127.0.0.1:8080/v1/signin
```

The response:

``` json
{
  "token": "0827379d-903c-41fb-8330-5382a4c87203"
}
```
